### PR TITLE
cowsay-files repo using main not master branch 

### DIFF
--- a/Formula/cowsay-files.rb
+++ b/Formula/cowsay-files.rb
@@ -2,7 +2,7 @@ class CowsayFiles < Formula
   desc "A collection of additional/alternative cowsay files"
   homepage "https://github.com/paulkaefer/cowsay-files"
   sha256 "af13a93f1559ea435403cf11eaa6c46be5bf03ac165a4acb471c66a4976167e0"
-  head "https://github.com/paulkaefer/cowsay-files.git"
+  head "https://github.com/paulkaefer/cowsay-files.git", branch: "main"
 
   def install
     system "make", "install", "prefix=#{prefix}"


### PR DESCRIPTION
cowboy-files repo using main not master branch 

```
==> Fetching cowsay-org/cowsay/cowsay-files
==> Cloning https://github.com/paulkaefer/cowsay-files.git
Cloning into '/Users/andrew/Library/Caches/Homebrew/cowsay-files--git'...
fatal: Remote branch master not found in upstream origin
Error: cowsay-files: Failed to download resource "cowsay-files"
Failure while executing; `/usr/bin/env git clone --branch master --config advice.detachedHead=false --config core.fsmonitor=false https://github.com/paulkaefer/cowsay-files.git /Users/andrew/Library/Caches/Homebrew/cowsay-files--git` exited with 128. Here's the output:
Cloning into '/Users/andrew/Library/Caches/Homebrew/cowsay-files--git'...
fatal: Remote branch master not found in upstream origin
```

As mentioned 
https://github.com/paulkaefer/cowsay-files/issues/32#issuecomment-1714391146
